### PR TITLE
Grabber centering

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -25,7 +25,7 @@ public final class Constants {
     // LEAVE THESE AT TOP OF FILE
     // NEVER DISABLE THESE IN MASTER BRANCH
     public static class FeatureFlags {
-        public static final boolean CHASSIS_ENABLED = true;
+        public static final boolean CHASSIS_ENABLED = false;
         public static final boolean ARM_ENABLED     = true;
         public static final boolean GRABBER_ENABLED = true;
         public static final boolean VISION_ENABLED  = false;
@@ -170,9 +170,9 @@ public final class Constants {
         public static final double kI_WRIST  = 0.1;
         public static final double kIZ_WRIST = 3;  // deg * 11
 
-        public static final double BASE_SEGMENT_EFFICIENCY  = 0.3; // 0.35;
-        public static final double ELBOW_SEGMENT_EFFICIENCY = 0.8; // 0.85;
-        public static final double WRIST_SEGMENT_EFFICIENCY = 1.0; // 0.7;
+        public static final double BASE_SEGMENT_EFFICIENCY  = 0.3;  // 0.35;
+        public static final double ELBOW_SEGMENT_EFFICIENCY = 0.85; // 0.85;
+        public static final double WRIST_SEGMENT_EFFICIENCY = 1.0;  // 0.7;
 
         public static final double BASE_SEGMENT_MASS  = Units.lbsToKilograms(9.5);
         public static final double ELBOW_SEGMENT_MASS = Units.lbsToKilograms(6.5);

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -213,6 +213,7 @@ public final class Constants {
         public static final double CLAW_PNEUMATIC_WAIT_TIME          = 0.1;
         public static final double MINIMUM_WRIST_ANGLE               = -90D;
         public static final double MAXIMUN_WRIST_ANGLE               = 90D;
+        public static final double RESET_WRIST_ANGLE                 = 0;
 
     }
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -87,7 +87,7 @@ public final class Constants {
         public static final double MAXIMUM_ANGULAR_VELOCITY = MAXIMUM_LINEAR_VELOCITY
                 / Math.hypot(MODULE_X, MODULE_Y);
 
-        public static final double SLOW_MODE_RATIO              = 0.2;
+        public static final double SLOW_MODE_RATIO = 0.2;
 
         public static final double MINIMUM_LINEAR_VELOCITY  = 0.05;
         public static final double MINIMUM_ANGULAR_VELOCITY = 0.01;
@@ -170,9 +170,9 @@ public final class Constants {
         public static final double kI_WRIST  = 0.1;
         public static final double kIZ_WRIST = 3;  // deg * 11
 
-        public static final double BASE_SEGMENT_EFFICIENCY  = 0.3;  // 0.35;
-        public static final double ELBOW_SEGMENT_EFFICIENCY = 0.85; // 0.85;
-        public static final double WRIST_SEGMENT_EFFICIENCY = 1.0;  // 0.7;
+        public static final double BASE_SEGMENT_EFFICIENCY  = 0.3; // 0.35;
+        public static final double ELBOW_SEGMENT_EFFICIENCY = 0.8; // 0.85;
+        public static final double WRIST_SEGMENT_EFFICIENCY = 1.0; // 0.7;
 
         public static final double BASE_SEGMENT_MASS  = Units.lbsToKilograms(9.5);
         public static final double ELBOW_SEGMENT_MASS = Units.lbsToKilograms(6.5);
@@ -203,13 +203,11 @@ public final class Constants {
 
     public static class Grabber {
         // public static final double GRABBER_WRIST_GEAR_RATIO=1D;
-        public static final double ZERO_ANGLE                        = 90D;
-        public static final int    SERVO_RANGE                       = 180;
+        public static final double ZERO_ANGLE                        = 79D;
+        public static final double SERVO_RANGE                       = 180D;
         public static final double TELEOP_ANGULAR_VELOCITY           = 90D;
         public static final double TELEOP_ANGULAR_VELOCITY_PER_CYCLE = TELEOP_ANGULAR_VELOCITY / 50;
         public static final double MAX_ANGULAR_VELOCITY              = 360D;
-        public static final int    FIRST_DOUBLE_SOLENOID_CHANNEL     = 11111;
-        public static final int    SECOND_DOUBLE_SOLENOID_CHANNEL    = 22222;
         public static final double CLAW_PNEUMATIC_WAIT_TIME          = 0.1;
         public static final double MINIMUM_WRIST_ANGLE               = -90D;
         public static final double MAXIMUN_WRIST_ANGLE               = 90D;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -9,6 +9,8 @@ import static frc.robot.Constants.FeatureFlags.CHASSIS_ENABLED;
 import static frc.robot.Constants.FeatureFlags.GRABBER_ENABLED;
 import static frc.robot.Constants.FeatureFlags.VISION_ENABLED;
 
+import static frc.robot.Constants.Grabber.RESET_WRIST_ANGLE;
+
 import java.util.Map;
 
 import edu.wpi.first.math.geometry.Pose2d;
@@ -136,20 +138,32 @@ public class RobotContainer {
             // controller1.leftBumper.onTrue(armWrist.setAngleCommandPos(9));
             // controller1.rightBumper.onTrue(elbow.setAngleCommandPos(4));
             // controller1.backButton.onTrue(armWrist.setAngleCommandPos(4));
-            controller1.yButton.onTrue(new SelectCommand(Map.ofEntries(
-                    Map.entry(CommandSelector.CONE, arm.moveSequentially(Arm.Position.UPPER_CONE)),
-                    Map.entry(CommandSelector.CUBE, arm.moveSequentially(Arm.Position.UPPER_CUBE))),
-                    this::selectModifier));
-            controller1.xButton.onTrue(new SelectCommand(Map.ofEntries(
-                    Map.entry(CommandSelector.CONE, arm.moveSequentially(Arm.Position.MIDDLE_CONE)),
-                    Map.entry(CommandSelector.CUBE,
-                            arm.moveSequentially(Arm.Position.MIDDLE_CUBE))),
-                    this::selectModifier));
+            controller1.yButton.onTrue(
+                    new SequentialCommandGroup(wrist.setWristAngleCommand(RESET_WRIST_ANGLE),
+                            new SelectCommand(
+                                    Map.ofEntries(
+                                            Map.entry(CommandSelector.CONE,
+                                                    arm.moveSequentially(Arm.Position.UPPER_CONE)),
+                                            Map.entry(CommandSelector.CUBE,
+                                                    arm.moveSequentially(Arm.Position.UPPER_CUBE))),
+                                    this::selectModifier)));
+            controller1.xButton.onTrue(
+                    new SequentialCommandGroup(wrist.setWristAngleCommand(RESET_WRIST_ANGLE),
+                            new SelectCommand(
+                                    Map.ofEntries(
+                                            Map.entry(CommandSelector.CONE,
+                                                    arm.moveSequentially(Arm.Position.MIDDLE_CONE)),
+                                            Map.entry(CommandSelector.CUBE,
+                                                    arm.moveSequentially(
+                                                            Arm.Position.MIDDLE_CUBE))),
+                                    this::selectModifier)));
             controller1.bButton.onTrue(new SelectCommand(Map.ofEntries(
                     Map.entry(CommandSelector.CONE, arm.moveSequentially(Arm.Position.LOWER_CONE)),
                     Map.entry(CommandSelector.CUBE, arm.moveSequentially(Arm.Position.LOWER_CUBE))),
                     this::selectModifier));
-            controller1.aButton.onTrue(arm.moveSequentially(Arm.Position.TRAVEL));
+            controller1.aButton.onTrue(
+                    new SequentialCommandGroup(arm.moveSequentially(Arm.Position.TRAVEL),
+                            wrist.setWristAngleCommand(RESET_WRIST_ANGLE)));
             controller1.startButton.onTrue(arm.armPanicCommand());
         }
         if (GRABBER_ENABLED) {
@@ -157,6 +171,9 @@ public class RobotContainer {
             wrist.setDefaultCommand(teleopWristCommand);
             controller1.leftStickButton.onTrue(claw.closeClawCommand());
             controller1.rightStickButton.onTrue(claw.openClawCommand());
+
+            // controller1.yButton.onTrue(wrist.setWristAngleCommand(0));
+            // controller1.xButton.onTrue(wrist.setWristAngleCommand(0));
         }
         if (GRABBER_ENABLED && ARM_ENABLED) {
             controller1.rightBumper.onTrue(new SequentialCommandGroup(claw.openClawCommand(),

--- a/src/main/java/frc/robot/commands/TeleopWristAngleCommand.java
+++ b/src/main/java/frc/robot/commands/TeleopWristAngleCommand.java
@@ -20,7 +20,7 @@ public class TeleopWristAngleCommand extends CommandBase {
     public void execute() {
         // If negative, rotate the wrist left by a set amount.
         // If positive, rotate the wrist right.
-        double x = controller.getDpad();
+        int x = controller.getDpad();
         if (x == 90) {
             x = 1;
         } else if (x == 270) {


### PR DESCRIPTION
Changed command schedule for scoring on upper levels to include zeroing the grabber wrist. Set the wrist zero angle constant to the correct value. May need to be undone depending on hardware fix.